### PR TITLE
Makes tester class into an interface so users can implement their own testers

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -5,7 +5,7 @@ A very simple go testing library.
 func TestSimple(t *testing.T) {
   test := quiz.Test(t)
 
-  test.Expect(1 == 2).toBeFalse()
+  test.Expect(1 == 2).ToBeFalse()
 }
 
 func TestSimple(t *testing.T) {

--- a/quiz.go
+++ b/quiz.go
@@ -1,37 +1,51 @@
 package quiz
 
 import (
-	"testing"
 	"fmt"
 	"runtime"
 	"strings"
+	"testing"
 )
 
-func Test(t *testing.T) *tester {
-	return &tester{t}
+func Test(t *testing.T) *defaultHarness {
+	return &defaultHarness{t}
 }
 
-type tester struct {
-	*testing.T
+type TestHarness interface {
+	Fail()
+	Log(string)
+	Expect(interface{}) *Expectation
 }
 
-func (t *tester) Expect(target interface{}) *expectation {
-	return &expectation{t: t, target: target}
+type defaultHarness struct {
+	t *testing.T
 }
 
-type expectation struct {
-	t *tester
+func (harness defaultHarness) Fail() {
+	harness.t.Fail()
+}
+
+func (harness defaultHarness) Log(line string) {
+	fmt.Printf(line)
+}
+
+func (harness defaultHarness) Expect(target interface{}) *Expectation {
+	return &Expectation{t: harness, target: target}
+}
+
+type Expectation struct {
+	t      TestHarness
 	target interface{}
 }
 
 type assertion struct {
-	failure bool
+	failure        bool
 	failureMessage string
-	messageParts []interface{}
-	expect *expectation
+	messageParts   []interface{}
+	expect         *Expectation
 }
 
-func (a assertion) eval(expect *expectation) {
+func (a assertion) eval(expect *Expectation) {
 	if a.failure {
 		_, file, line, _ := runtime.Caller(2)
 		expect.t.Fail()
@@ -39,53 +53,53 @@ func (a assertion) eval(expect *expectation) {
 	}
 }
 
-func (expect *expectation) ToEqual(value interface{}) {
+func (expect *Expectation) ToEqual(value interface{}) {
 	assertion{
-		failure: expect.target != value,
+		failure:        expect.target != value,
 		failureMessage: "Expected %s to equal %s.",
-		messageParts: []interface{}{value, expect.target},
+		messageParts:   []interface{}{value, expect.target},
 	}.eval(expect)
 }
 
-func (expect *expectation) ToBeTrue() {
+func (expect *Expectation) ToBeTrue() {
 	assertion{
-		failure: expect.target != true,
+		failure:        expect.target != true,
 		failureMessage: "Expected %s to be true.",
-		messageParts: []interface{}{expect.target},
+		messageParts:   []interface{}{expect.target},
 	}.eval(expect)
 }
 
-func (expect *expectation) ToBeFalse() {
+func (expect *Expectation) ToBeFalse() {
 	assertion{
-		failure: expect.target != false,
+		failure:        expect.target != false,
 		failureMessage: "Expected %s to be false.",
-		messageParts: []interface{}{expect.target},
+		messageParts:   []interface{}{expect.target},
 	}.eval(expect)
 }
 
-func (expect *expectation) ToBeLessThan(value int) {
+func (expect *Expectation) ToBeLessThan(value int) {
 	intTarget := expect.target.(int)
 	assertion{
-		failure: intTarget > value,
+		failure:        intTarget > value,
 		failureMessage: "Expected %s to be less tahn %s.",
-		messageParts: []interface{}{expect.target, value},
+		messageParts:   []interface{}{expect.target, value},
 	}.eval(expect)
 }
 
-func (expect *expectation) ToBeGreaterThan(value int) {
+func (expect *Expectation) ToBeGreaterThan(value int) {
 	intTarget := expect.target.(int)
 	assertion{
-		failure: intTarget < value,
+		failure:        intTarget < value,
 		failureMessage: "Expected %s to be greater than %s.",
-		messageParts: []interface{}{expect.target, value},
+		messageParts:   []interface{}{expect.target, value},
 	}.eval(expect)
 }
 
-func (expect *expectation) ToContain(value string) {
+func (expect *Expectation) ToContain(value string) {
 	stringTarget := expect.target.(string)
 	assertion{
-		failure: !strings.Contains(stringTarget, value),
+		failure:        !strings.Contains(stringTarget, value),
 		failureMessage: "Expected %s to contain %s.",
-		messageParts: []interface{}{expect.target, value},
+		messageParts:   []interface{}{expect.target, value},
 	}.eval(expect)
 }

--- a/quiz.go
+++ b/quiz.go
@@ -49,7 +49,7 @@ func (a assertion) eval(expect *Expectation) {
 	if a.failure {
 		_, file, line, _ := runtime.Caller(2)
 		expect.t.Fail()
-		fmt.Printf(a.failureMessage+"\n  %s:%d\n", append(a.messageParts, file, line)...)
+		expect.t.Log(fmt.Sprintf(a.failureMessage+"\n  %s:%d\n", append(a.messageParts, file, line)...))
 	}
 }
 

--- a/quiz.go
+++ b/quiz.go
@@ -60,7 +60,7 @@ func (a assertion) eval(expect *Expectation) {
 func (expect *Expectation) ToEqual(value interface{}) {
 	assertion{
 		failure:        expect.target != value,
-		failureMessage: "Expected %s to equal %s.",
+		failureMessage: "Expected %v to equal %v.",
 		messageParts:   []interface{}{value, expect.target},
 	}.eval(expect)
 }
@@ -68,7 +68,7 @@ func (expect *Expectation) ToEqual(value interface{}) {
 func (expect *Expectation) ToBeTrue() {
 	assertion{
 		failure:        expect.target != true,
-		failureMessage: "Expected %s to be true.",
+		failureMessage: "Expected %v to be true.",
 		messageParts:   []interface{}{expect.target},
 	}.eval(expect)
 }
@@ -76,7 +76,7 @@ func (expect *Expectation) ToBeTrue() {
 func (expect *Expectation) ToBeFalse() {
 	assertion{
 		failure:        expect.target != false,
-		failureMessage: "Expected %s to be false.",
+		failureMessage: "Expected %v to be false.",
 		messageParts:   []interface{}{expect.target},
 	}.eval(expect)
 }
@@ -85,7 +85,7 @@ func (expect *Expectation) ToBeLessThan(value int) {
 	intTarget := expect.target.(int)
 	assertion{
 		failure:        intTarget > value,
-		failureMessage: "Expected %s to be less tahn %s.",
+		failureMessage: "Expected %v to be less than %v.",
 		messageParts:   []interface{}{expect.target, value},
 	}.eval(expect)
 }
@@ -94,7 +94,7 @@ func (expect *Expectation) ToBeGreaterThan(value int) {
 	intTarget := expect.target.(int)
 	assertion{
 		failure:        intTarget < value,
-		failureMessage: "Expected %s to be greater than %s.",
+		failureMessage: "Expected %v to be greater than %v.",
 		messageParts:   []interface{}{expect.target, value},
 	}.eval(expect)
 }

--- a/quiz.go
+++ b/quiz.go
@@ -11,6 +11,10 @@ func Test(t *testing.T) *defaultHarness {
 	return &defaultHarness{t}
 }
 
+func NewExpecation(t TestHarness, target interface{}) *Expectation {
+	return &Expectation{t: t, target: target}
+}
+
 type TestHarness interface {
 	Fail()
 	Log(string)

--- a/quiz_test.go
+++ b/quiz_test.go
@@ -1,137 +1,137 @@
 package quiz
 
 import (
-  "testing"
-  "strings"
+	"strings"
+	"testing"
 )
 
 func newHarness() *testHelperHarness {
-  return &testHelperHarness{false, ""}
+	return &testHelperHarness{false, ""}
 }
 
 type testHelperHarness struct {
-  Failed bool
-  Message string
+	Failed  bool
+	Message string
 }
 
 func (t *testHelperHarness) Fail() {
-  t.Failed = true
+	t.Failed = true
 }
 
 func (t *testHelperHarness) Log(line string) {
-  t.Message = line
+	t.Message = line
 }
 
 func (t *testHelperHarness) Expect(target interface{}) *Expectation {
-  return &Expectation{t: t, target: target}
+	return &Expectation{t: t, target: target}
 }
 
 func TestToEqual(t *testing.T) {
 	h := newHarness()
 
-  h.Expect(2).ToEqual(2)
+	h.Expect(2).ToEqual(2)
 
-  if h.Failed {
-    t.Fail()
-  }
+	if h.Failed {
+		t.Fail()
+	}
 }
 
 func TestToEqualFail(t *testing.T) {
 	h := newHarness()
 
-  h.Expect(1).ToEqual(2)
+	h.Expect(1).ToEqual(2)
 
-  if !strings.Contains(h.Message, "Expected 2 to equal 1.") {
-    t.Fail()
-  }
+	if !strings.Contains(h.Message, "Expected 2 to equal 1.") {
+		t.Fail()
+	}
 }
 
 func TestToBeFalse(t *testing.T) {
-  h := newHarness()
+	h := newHarness()
 
-  h.Expect(1 == 2).ToBeFalse()
+	h.Expect(1 == 2).ToBeFalse()
 
-  if h.Failed {
-    t.Fail()
-  }
+	if h.Failed {
+		t.Fail()
+	}
 }
 
 func TestToBeFalseFail(t *testing.T) {
-  h := newHarness()
+	h := newHarness()
 
-  h.Expect(2 == 2).ToBeFalse()
+	h.Expect(2 == 2).ToBeFalse()
 
-  if !strings.Contains(h.Message, "Expected true to be false") {
-    t.Fail()
-  }
+	if !strings.Contains(h.Message, "Expected true to be false") {
+		t.Fail()
+	}
 }
 
 func TestToBeTrue(t *testing.T) {
-  h := newHarness()
+	h := newHarness()
 
-  h.Expect(1 == 1).ToBeTrue()
+	h.Expect(1 == 1).ToBeTrue()
 
-  if h.Failed {
-    t.Fail()
-  }
+	if h.Failed {
+		t.Fail()
+	}
 }
 
 func TestToBeTrueFail(t *testing.T) {
-  h := newHarness()
+	h := newHarness()
 
-  h.Expect(2 == 3).ToBeTrue()
+	h.Expect(2 == 3).ToBeTrue()
 
-  if !strings.Contains(h.Message, "Expected false to be true") {
-    t.Fail()
-  }
+	if !strings.Contains(h.Message, "Expected false to be true") {
+		t.Fail()
+	}
 }
 
 func TestToBeGreaterThan(t *testing.T) {
-  h := newHarness()
+	h := newHarness()
 
-  h.Expect(1).ToBeGreaterThan(0)
+	h.Expect(1).ToBeGreaterThan(0)
 
-  if h.Failed {
-    t.Fail()
-  }
+	if h.Failed {
+		t.Fail()
+	}
 }
 
 func TestToBeGreaterThanFail(t *testing.T) {
-  h := newHarness()
+	h := newHarness()
 
-  h.Expect(0).ToBeGreaterThan(1)
+	h.Expect(0).ToBeGreaterThan(1)
 
-  if !strings.Contains(h.Message, "Expected 0 to be greater than 1") {
-    t.Fail()
-  }
+	if !strings.Contains(h.Message, "Expected 0 to be greater than 1") {
+		t.Fail()
+	}
 }
 
 func TestToBeLessThan(t *testing.T) {
-  h := newHarness()
+	h := newHarness()
 
-  h.Expect(1).ToBeLessThan(2)
+	h.Expect(1).ToBeLessThan(2)
 
-  if h.Failed {
-    t.Fail()
-  }
+	if h.Failed {
+		t.Fail()
+	}
 }
 
 func TestToContain(t *testing.T) {
-  h := newHarness()
+	h := newHarness()
 
-  h.Expect("Hello world").ToContain("world")
+	h.Expect("Hello world").ToContain("world")
 
-  if h.Failed {
-    t.Fail()
-  }
+	if h.Failed {
+		t.Fail()
+	}
 }
 
 func TestToContainFail(t *testing.T) {
-  h := newHarness()
+	h := newHarness()
 
-  h.Expect("Hello world").ToContain("Goodbye")
+	h.Expect("Hello world").ToContain("Goodbye")
 
-  if !strings.Contains(h.Message, "Expected Hello world to contain Goodbye") {
-    t.Fail()
-  }
+	if !strings.Contains(h.Message, "Expected Hello world to contain Goodbye") {
+		t.Fail()
+	}
 }

--- a/quiz_test.go
+++ b/quiz_test.go
@@ -1,20 +1,137 @@
 package quiz
 
-import "testing"
+import (
+  "testing"
+  "strings"
+)
 
-func TestSimple(t *testing.T) {
-	test := Test(t)
-
-	test.Expect(1 == 2).ToBeFalse()
+func newHarness() *testHelperHarness {
+  return &testHelperHarness{false, ""}
 }
 
-func TestSimpleTwo(t *testing.T) {
-	test := Test(t)
+type testHelperHarness struct {
+  Failed bool
+  Message string
+}
 
-	test.Expect(1).ToEqual(1)
-	test.Expect(1 == 2).ToBeFalse()
-	test.Expect(1 == 1).ToBeTrue()
-	test.Expect(1).ToBeGreaterThan(0)
-	test.Expect(1).ToBeLessThan(2)
-	test.Expect("hello world").ToContain("world")
+func (t *testHelperHarness) Fail() {
+  t.Failed = true
+}
+
+func (t *testHelperHarness) Log(line string) {
+  t.Message = line
+}
+
+func (t *testHelperHarness) Expect(target interface{}) *Expectation {
+  return &Expectation{t: t, target: target}
+}
+
+func TestToEqual(t *testing.T) {
+	h := newHarness()
+
+  h.Expect(2).ToEqual(2)
+
+  if h.Failed {
+    t.Fail()
+  }
+}
+
+func TestToEqualFail(t *testing.T) {
+	h := newHarness()
+
+  h.Expect(1).ToEqual(2)
+
+  if !strings.Contains(h.Message, "Expected 2 to equal 1.") {
+    t.Fail()
+  }
+}
+
+func TestToBeFalse(t *testing.T) {
+  h := newHarness()
+
+  h.Expect(1 == 2).ToBeFalse()
+
+  if h.Failed {
+    t.Fail()
+  }
+}
+
+func TestToBeFalseFail(t *testing.T) {
+  h := newHarness()
+
+  h.Expect(2 == 2).ToBeFalse()
+
+  if !strings.Contains(h.Message, "Expected true to be false") {
+    t.Fail()
+  }
+}
+
+func TestToBeTrue(t *testing.T) {
+  h := newHarness()
+
+  h.Expect(1 == 1).ToBeTrue()
+
+  if h.Failed {
+    t.Fail()
+  }
+}
+
+func TestToBeTrueFail(t *testing.T) {
+  h := newHarness()
+
+  h.Expect(2 == 3).ToBeTrue()
+
+  if !strings.Contains(h.Message, "Expected false to be true") {
+    t.Fail()
+  }
+}
+
+func TestToBeGreaterThan(t *testing.T) {
+  h := newHarness()
+
+  h.Expect(1).ToBeGreaterThan(0)
+
+  if h.Failed {
+    t.Fail()
+  }
+}
+
+func TestToBeGreaterThanFail(t *testing.T) {
+  h := newHarness()
+
+  h.Expect(0).ToBeGreaterThan(1)
+
+  if !strings.Contains(h.Message, "Expected 0 to be greater than 1") {
+    t.Fail()
+  }
+}
+
+func TestToBeLessThan(t *testing.T) {
+  h := newHarness()
+
+  h.Expect(1).ToBeLessThan(2)
+
+  if h.Failed {
+    t.Fail()
+  }
+}
+
+func TestToContain(t *testing.T) {
+  h := newHarness()
+
+  h.Expect("Hello world").ToContain("world")
+
+  if h.Failed {
+    t.Fail()
+  }
+}
+
+func TestToContainFail(t *testing.T) {
+  h := newHarness()
+
+  h.Expect("Hello world").ToContain("Goodbye")
+
+  if !strings.Contains(h.Message, "Expected Hello world to contain Goodbye") {
+    t.Fail()
+  }
 }

--- a/quiz_test.go
+++ b/quiz_test.go
@@ -1,0 +1,20 @@
+package quiz
+
+import "testing"
+
+func TestSimple(t *testing.T) {
+	test := Test(t)
+
+	test.Expect(1 == 2).ToBeFalse()
+}
+
+func TestSimpleTwo(t *testing.T) {
+	test := Test(t)
+
+	test.Expect(1).ToEqual(1)
+	test.Expect(1 == 2).ToBeFalse()
+	test.Expect(1 == 1).ToBeTrue()
+	test.Expect(1).ToBeGreaterThan(0)
+	test.Expect(1).ToBeLessThan(2)
+	test.Expect("hello world").ToContain("world")
+}


### PR DESCRIPTION
Right now the assertions are pretty cool, but we're coupled to the default Go test harness. This makes the test harness into an interface type and provides a default test harness type so that the API is unchanged.

Also you hadn't gofmted your shit. Fixed that for ya, scrub
