### PR TITLE
Use FailNow() instead of Fail()

### DIFF
--- a/quiz.go
+++ b/quiz.go
@@ -16,7 +16,7 @@ func NewExpectation(t TestHarness, target interface{}) *Expectation {
 }
 
 type TestHarness interface {
-	Fail()
+	FailNow()
 	Log(string)
 	Expect(interface{}) *Expectation
 }
@@ -25,8 +25,8 @@ type defaultHarness struct {
 	t *testing.T
 }
 
-func (harness defaultHarness) Fail() {
-	harness.t.Fail()
+func (harness defaultHarness) FailNow() {
+	harness.t.FailNow ()
 }
 
 func (harness defaultHarness) Log(line string) {
@@ -52,7 +52,7 @@ type assertion struct {
 func (a assertion) eval(expect *Expectation) {
 	if a.failure {
 		_, file, line, _ := runtime.Caller(2)
-		expect.t.Fail()
+		expect.t.FailNow()
 		expect.t.Log(fmt.Sprintf(a.failureMessage+"\n  %s:%d\n", append(a.messageParts, file, line)...))
 	}
 }

--- a/quiz.go
+++ b/quiz.go
@@ -26,7 +26,7 @@ type defaultHarness struct {
 }
 
 func (harness defaultHarness) FailNow() {
-	harness.t.FailNow ()
+	harness.t.FailNow()
 }
 
 func (harness defaultHarness) Log(line string) {
@@ -52,8 +52,8 @@ type assertion struct {
 func (a assertion) eval(expect *Expectation) {
 	if a.failure {
 		_, file, line, _ := runtime.Caller(2)
-		expect.t.FailNow()
 		expect.t.Log(fmt.Sprintf(a.failureMessage+"\n  %s:%d\n", append(a.messageParts, file, line)...))
+		expect.t.FailNow()
 	}
 }
 

--- a/quiz.go
+++ b/quiz.go
@@ -11,7 +11,7 @@ func Test(t *testing.T) *defaultHarness {
 	return &defaultHarness{t}
 }
 
-func NewExpecation(t TestHarness, target interface{}) *Expectation {
+func NewExpectation(t TestHarness, target interface{}) *Expectation {
 	return &Expectation{t: t, target: target}
 }
 


### PR DESCRIPTION
This allows us to piggy back on some of the testing package's goroutine management.
